### PR TITLE
Adding `AudioObject` and minor corrections

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
 
 								<pre class="example" title="Author of a book">
 		{
-		    "type"     : "Book",
+		    "type"     : "Audiobook",
 		    "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
 		    &#8230;
 		    "url"      : "https://publisher.example.org/janeeyre",
@@ -269,7 +269,7 @@
 
 								<pre class="example" title="Author and Narrator of an Audiobook">
 		{
-				"type"		: "Book";
+				"type"		: "Audiobook";
 				"@context": ["https://schema.org", "https://www.w3.org/ns/wp-context"],
 				&#8230;
 				"url"			: "https://publisher.example.org/janeeyre",
@@ -294,7 +294,7 @@
 
 								<pre class="example" title="Duration of an Audiobook in Hours">
 									{
-									    "type"     : "Book",
+									    "type"     : "Audiobook",
 									    "@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
 									    &#8230;
 									    "url"      : "https://publisher.example.org/janeeyre",
@@ -308,7 +308,7 @@
 
 								<pre class="example" title="Duration of an Audiobook in Seconds">
 									{
-											"type"     : "Book",
+											"type"     : "Audiobook",
 											"@context" : ["https://schema.org","https://www.w3.org/ns/wp-context"],
 											&#8230;
 											"url"      : "https://publisher.example.org/janeeyre",
@@ -327,7 +327,7 @@
 
 							<p>The <a href="https://w3c.github.io/wpub/index.html#default-reading-order"><dfn>default reading order</dfn></a> is a specific progression through the audio resources in the audiobook.</p>
 
-							<p>The default reading order MUST contain at least one audio resource.</p>
+							<p>The default reading order MUST contain at least one audio resource, which MAY be identified by the <code>type</code> of <a href="https://schema.org/AudioObject"><code>AudioObject</code></a> [[schema.org]].</p>
 
 							<pre class="example" title="Audiobook Reading Order for a Single Resource">
 								{
@@ -336,7 +336,7 @@
 									"url"			 : "https://publisher.example.org/janeeyre",
 									"name"		 : "Jane Eyre",
 									"readingOrder" : [{
-										"type"	: "MediaObject",
+										"type"	: "AudioObject",
 										"url"   : "audio/janeeyre.mp3",
 										"encodingFormat" : "audio/mp3",
 										"name"  : "Jane Eyre",
@@ -352,13 +352,13 @@
 									"url"			 : "https://publisher.example.org/janeeyre",
 									"name"		 : "Jane Eyre",
 									"readingOrder" : [{
-										"type"	: "MediaObject",
+										"type"	: "AudioObject",
 										"url"   : "audio/part001.mp3#0",
 										"encodingFormat" : "audio/mp3",
 										"name"  : "Chapter 1",
 										"duration" : "457.931"
 									}, {
-										"type"  : "MediaObject",
+										"type"  : "AudioObject",
 										"url"   : "audio/part001.mp3#457.932",
 										"encodingFormat" : "audio/mp3",
 										"name"  : "Chapter 2",
@@ -411,7 +411,7 @@
 			<section id="audio-simple">
 				<h3>Simple Audiobook</h3>
 				<p>A manifest for an audiobook. The <a
-						href="https://w3c.github.io/wpub/experiments/audiobook/flatland-canonical.json">canonical
+						href="https://github.com/w3c/wpub/blob/master/experiments/audiobook/flatland-canonical.json">canonical
 						version</a> of this manifest is also available.</p>
 				<pre class="example" data-include="https://github.com/w3c/wpub/experiments/audiobook/flatland.json" data-include-format="text"></pre>
 			</section>

--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@
 
 							<p>The default reading order MUST contain at least one audio resource, which MAY be identified by the <code>type</code> of <a href="https://w3c.github.io/wpub/index.html#app-linkedResource"><code>LinkedResource</code></a>.</p>
 
-							<p class="ednote">The relationship to LinkedResource is explained in the core specification. The Working Group is exploring including <code>AudioObject</code> as well.</p>
+							<p class="ednote">The relationship to LinkedResource is explained in the core specification. The Working Group is exploring including <a href="https://schema.org/AudioObject"><code>AudioObject</code></a> as well [[schema.org]].</p>
 
 							<pre class="example" title="Audiobook Reading Order for a Single Resource">
 								{

--- a/index.html
+++ b/index.html
@@ -327,7 +327,9 @@
 
 							<p>The <a href="https://w3c.github.io/wpub/index.html#default-reading-order"><dfn>default reading order</dfn></a> is a specific progression through the audio resources in the audiobook.</p>
 
-							<p>The default reading order MUST contain at least one audio resource, which MAY be identified by the <code>type</code> of <a href="https://schema.org/AudioObject"><code>AudioObject</code></a> [[schema.org]].</p>
+							<p>The default reading order MUST contain at least one audio resource, which MAY be identified by the <code>type</code> of <a href="https://w3c.github.io/wpub/index.html#app-linkedResource"><code>LinkedResource</code></a>.</p>
+
+							<p class="ednote">The relationship to LinkedResource is explained in the core specification. The Working Group is exploring including <code>AudioObject</code> as well.</p>
 
 							<pre class="example" title="Audiobook Reading Order for a Single Resource">
 								{
@@ -336,7 +338,7 @@
 									"url"			 : "https://publisher.example.org/janeeyre",
 									"name"		 : "Jane Eyre",
 									"readingOrder" : [{
-										"type"	: "AudioObject",
+										"type"	: "LinkedResource",
 										"url"   : "audio/janeeyre.mp3",
 										"encodingFormat" : "audio/mp3",
 										"name"  : "Jane Eyre",
@@ -352,13 +354,13 @@
 									"url"			 : "https://publisher.example.org/janeeyre",
 									"name"		 : "Jane Eyre",
 									"readingOrder" : [{
-										"type"	: "AudioObject",
+										"type"	: "LinkedResource",
 										"url"   : "audio/part001.mp3#0",
 										"encodingFormat" : "audio/mp3",
 										"name"  : "Chapter 1",
 										"duration" : "457.931"
 									}, {
-										"type"  : "AudioObject",
+										"type"  : "LinkedResource",
 										"url"   : "audio/part001.mp3#457.932",
 										"encodingFormat" : "audio/mp3",
 										"name"  : "Chapter 2",
@@ -413,7 +415,7 @@
 				<p>A manifest for an audiobook. The <a
 						href="https://github.com/w3c/wpub/blob/master/experiments/audiobook/flatland-canonical.json">canonical
 						version</a> of this manifest is also available.</p>
-				<pre class="example" data-include="https://github.com/w3c/wpub/experiments/audiobook/flatland.json" data-include-format="text"></pre>
+				<pre class="example" data-include="https://github.com/w3c/wpub/blob/master/experiments/audiobook/flatland.json" data-include-format="text"></pre>
 			</section>
 
 			<section id="audio-supplemental">


### PR DESCRIPTION
Adding the usage of `AudioObject` for items in the readingOrder. After reviewing the `AudioObject` in schema.org I think this is a grat type option for reading order items, it gives us all of the attributes we need.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wareid/audiobooks/pull/4.html" title="Last updated on Jun 11, 2019, 3:33 PM UTC (acfd09e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/4/58932bb...wareid:acfd09e.html" title="Last updated on Jun 11, 2019, 3:33 PM UTC (acfd09e)">Diff</a>