### PR TITLE
Fix various w3.org related typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -477,7 +477,7 @@
 		<section id="security-privacy">
 			<h3>Security and Privacy Considerations</h3>
 
-			<p>As Audiobooks is a profile of Publication Manifest [[pub-manifest]], all <a href="https://w3c.org/TR/pub-manifest/#security-privacy">security and privacy</a> considerations detailed in that specification are applicable to this profile.</p>
+			<p>As Audiobooks is a profile of Publication Manifest [[pub-manifest]], all <a href="https://www.w3.org/TR/pub-manifest/#security-privacy">security and privacy</a> considerations detailed in that specification are applicable to this profile.</p>
 
 			<p>This profile acknowledges the following considerations:</p>
 
@@ -504,7 +504,7 @@
 				<p>A manifest for an audiobook with supplemental content.</a>
 				<pre class="example">
 					{
-						"@context": ["https://schema.org", "https://www.w3/org/ns/wp-context"],
+						"@context": ["https://schema.org", "https://www.w3.org/ns/wp-context"],
 						"type": "Audiobook",
 						"id": "https://publisher.example.com/janeeyre",
 						"url": "https://publisher.example.com/janeeyre",

--- a/snapshot/index.html
+++ b/snapshot/index.html
@@ -1256,7 +1256,7 @@ var[data-type]:hover::before {
 		<section id="security-privacy">
 			<h3 id="x2-3-security-and-privacy-considerations"><bdi class="secno">2.3 </bdi>Security and Privacy Considerations<a class="self-link" aria-label="§" href="#security-privacy"></a></h3>
 
-			<p>As Audiobooks is a profile of Publication Manifest [<cite><a class="bibref" href="#bib-pub-manifest" title="Publication Manifest" data-link-type="biblio">pub-manifest</a></cite>], all <a href="https://w3c.org/TR/pub-manifest/#security-privacy">security and privacy</a> considerations detailed in that specification are applicable to this profile.</p>
+			<p>As Audiobooks is a profile of Publication Manifest [<cite><a class="bibref" href="#bib-pub-manifest" title="Publication Manifest" data-link-type="biblio">pub-manifest</a></cite>], all <a href="https://www.w3.org/TR/pub-manifest/#security-privacy">security and privacy</a> considerations detailed in that specification are applicable to this profile.</p>
 
 			<p>This profile acknowledges the following considerations:</p>
 
@@ -1364,7 +1364,7 @@ var[data-type]:hover::before {
           <div class="marker">
       <a class="self-link" href="#example-13">Example<bdi> 13</bdi></a>
     </div> <pre aria-busy="false"><code class="hljs json">{
-	<span class="hljs-attr">"@context"</span>: [<span class="hljs-string">"https://schema.org"</span>, <span class="hljs-string">"https://www.w3/org/ns/wp-context"</span>],
+	<span class="hljs-attr">"@context"</span>: [<span class="hljs-string">"https://schema.org"</span>, <span class="hljs-string">"https://www.w3.org/ns/wp-context"</span>],
 	<span class="hljs-attr">"type"</span>: <span class="hljs-string">"Audiobook"</span>,
 	<span class="hljs-attr">"id"</span>: <span class="hljs-string">"https://publisher.example.com/janeeyre"</span>,
 	<span class="hljs-attr">"url"</span>: <span class="hljs-string">"https://publisher.example.com/janeeyre"</span>,


### PR DESCRIPTION
I updated the snapshot also...not sure if that's how it's done or not. 😃 

`https://w3c.org/` throws a security warning...which is how I found these.

Cheers!
🎩


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/pull/21.html" title="Last updated on Sep 16, 2019, 2:40 AM UTC (1dc40bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/21/93ed099...1dc40bc.html" title="Last updated on Sep 16, 2019, 2:40 AM UTC (1dc40bc)">Diff</a>