### PR TITLE
check if reading order is empty after processing entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -578,13 +578,16 @@
 						<li id="validate-readingorder">
 							<p>(<a href="#audio-readingorder"></a>) Check the reading order as follows:</p>
 							<ol>
-								<li id="validate-ro-empty">
-									<p>if <var>data["readingOrder"]</var> is not set or is an empty <a href="https://infra.spec.whatwg.org/#list">list</a>, <a href="https://www.w3.org/TR/pub-manifest/#fatal-error">fatal error</a>, return failure. Otherwise, if <var>data["readingOrder"]</var> does not <a href="https://infra.spec.whatwg.org/#list-contain">contain</a> at least one <a href="https://infra.spec.whatwg.org/#list-item">item</a> with an audio media type, <a href="https://www.w3.org/TR/pub-manifest/#fatal-error">fatal error</a>, return failure.</p>
+								<li id="validate-ro-none">
+									<p>if <var>data["readingOrder"]</var> is not set, <a href="https://www.w3.org/TR/pub-manifest/#fatal-error">fatal error</a>.</p>
 								</li>
 								<li id="validate-ro-audio">
-									<p>otherwise, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+									<p><a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
 										<var>resource</var> in <var>data["readingOrder"]</var>, if <var>resource</var> is not an audio resource, <a href="https://www.w3.org/TR/pub-manifest/#validation-error">validation error</a>, <a href="https://infra.spec.whatwg.org/#list-remove">remove</a>
 										<var>resource</var> from <var>data["readingOrder"]</var>.</p>
+								</li>
+								<li id="validate-ro-empty">
+									<p>if <var>data["readingOrder"]</var> is an empty <a href="https://infra.spec.whatwg.org/#list">list</a>, <a href="https://www.w3.org/TR/pub-manifest/#fatal-error">fatal error</a>.</p>
 								</li>
 							</ol>
 						</li>


### PR DESCRIPTION
Sorry, I just noticed a bug with the processing - checking/removing non-audio resources can result in an empty reading order, but the fatal error for an empty reading order currently precedes this step. It also isn't necessary to check if there is at least one audio resource before removing non-audio resources, since the fatal error ensures the reading order is non-empty.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/pull/59.html" title="Last updated on Nov 22, 2019, 3:30 PM UTC (fc857ca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/59/31d87aa...fc857ca.html" title="Last updated on Nov 22, 2019, 3:30 PM UTC (fc857ca)">Diff</a>