### PR TITLE
Adjusting the text for Media fragments

### DIFF
--- a/index.html
+++ b/index.html
@@ -420,8 +420,8 @@
 
 				<p class="note">It is important to note that a resource cannot be referenced more than once in the
 					reading order. In the case where an audio file represents the content of multiple chapters or
-					sections of the book, <a href="audio-toc">table of contents</a> can be used to specify the starting
-					and ending points of those chapters in the larger audio file, as demonstrated in <a
+					sections of the book, the <a href="audio-toc">table of contents</a> can be used to specify the
+					starting and ending points of those chapters in the larger audio file, as demonstrated in <a
 						href="#toc-mediafragments">this example</a>.</p>
 
 				<pre class="example" title="Audiobook Reading Order for a Single Resource">
@@ -454,7 +454,7 @@
 									"duration" : "PT457.931S"
 								}, {
 									"type" : "LinkedResource",
-									"url" : "audio/part002.wav#t=457.932",
+									"url" : "audio/part002.wav#t=12.741",
 									"encodingFormat" : "audio/vnd-wav",
 									"name" : "Chapter 2",
 									"duration" : "PT234.245S"
@@ -578,7 +578,7 @@
 							"encodingFormat" : "application/vnd.syncnarr+json"}
 					}, {
 						"type" : "LinkedResource",
-						"url" : "audio/part002.wav#t=457.932",
+						"url" : "audio/part002.wav#t=12.741",
 						"encodingFormat" : "audio/vnd-wav",
 						"name" : "Chapter 2",
 						"duration" : "PT234.245S",

--- a/index.html
+++ b/index.html
@@ -418,7 +418,11 @@
 					chapters occupy a single file by using <a href="https://www.w3.org/TR/media-frags/">media
 						fragments</a> [[media-frags]] to locate the exact starting and end points.</p>
 
-				<p class="note">It is important to note that a resource cannot be referenced more than once in the reading order. In the case where an audio file represents the content of multiple chapters or sections of the book, content creators should use a <a href="audio-toc">table of contents</a> to specify the starting and ending points of those chapters in the larger audio file, as demonstrated in example <a href="#toc-mediafragments">this example</a>.</p>
+				<p class="note">It is important to note that a resource cannot be referenced more than once in the
+					reading order. In the case where an audio file represents the content of multiple chapters or
+					sections of the book, <a href="audio-toc">table of contents</a> can be used to specify the starting
+					and ending points of those chapters in the larger audio file, as demonstrated in <a
+						href="#toc-mediafragments">this example</a>.</p>
 
 				<pre class="example" title="Audiobook Reading Order for a Single Resource">
 							{

--- a/index.html
+++ b/index.html
@@ -416,7 +416,9 @@
 
 				<p>An audio resource can be referenced in its entirety via a URL [[url]], or for content where multiple
 					chapters occupy a single file by using <a href="https://www.w3.org/TR/media-frags/">media
-						fragments</a> [[media-frags]] to locate the exact starting point.</p>
+						fragments</a> [[media-frags]] to locate the exact starting and end points.</p>
+
+				<p class="note">It is important to note that a resource cannot be referenced more than once in the reading order. In the case where an audio file represents the content of multiple chapters or sections of the book, content creators should use a <a href="audio-toc">table of contents</a> to specify the starting and ending points of those chapters in the larger audio file, as demonstrated in example <a href="#toc-mediafragments">this example</a>.</p>
 
 				<pre class="example" title="Audiobook Reading Order for a Single Resource">
 							{
@@ -442,13 +444,13 @@
 								"name" : "Jane Eyre",
 								"readingOrder" : [{
 									"type": "LinkedResource",
-									"url" : "audio/part001.wav#0",
+									"url" : "audio/part001.wav#t=0,457.931",
 									"encodingFormat" : "audio/vnd-wav",
 									"name" : "Chapter 1",
 									"duration" : "PT457.931S"
 								}, {
 									"type" : "LinkedResource",
-									"url" : "audio/part001.wav#457.932",
+									"url" : "audio/part002.wav#t=457.932",
 									"encodingFormat" : "audio/vnd-wav",
 									"name" : "Chapter 2",
 									"duration" : "PT234.245S"
@@ -602,7 +604,7 @@
 					"name" : "Jane Eyre",
 					"readingOrder" : {
 						"type" : "LinkedResource",
-						"url" : "audio/part001.wav#0",
+						"url" : "audio/part001.wav#t=0",
 						"encodingFormat" : "audio/vnd-wav",
 						"name" : "Chapter 1",
 						"duration" : "PT457.931S",
@@ -1049,8 +1051,8 @@
 						&lt;h2>JANE EYRE&lt;/h2>
 
 						&lt;ol>
-							&lt;li>&lt;a href="https://example.publisher.org/janeeyre/part001.mp3">Chapter 1&lt;/a>&lt;/li>
-							&lt;li>&lt;a href="https://example.publisher.org/janeeyre/part001.mp3#t=456.789">Chapter 2&lt;/a>&lt;/li>
+							&lt;li>&lt;a href="https://example.publisher.org/janeeyre/part001.mp3#t=0,456.788">Chapter 1&lt;/a>&lt;/li>
+							&lt;li>&lt;a href="https://example.publisher.org/janeeyre/part001.mp3#t=456.789,1234.566">Chapter 2&lt;/a>&lt;/li>
 							&lt;li>&lt;a href="https://example.publisher.org/janeeyre/part001.mp3#t=1234.567">Chapter 3&lt;/a>&lt;/li>
 						&lt;/ol>
 					&lt;/nav>

--- a/index.html
+++ b/index.html
@@ -574,7 +574,7 @@
 							"encodingFormat" : "application/vnd.syncnarr+json"}
 					}, {
 						"type" : "LinkedResource",
-						"url" : "audio/part001.wav#t=457.932",
+						"url" : "audio/part002.wav#t=457.932",
 						"encodingFormat" : "audio/vnd-wav",
 						"name" : "Chapter 2",
 						"duration" : "PT234.245S",


### PR DESCRIPTION
Addressing the issue raised in #68

* corrected the time references
* edited the TOC example with media fragments
* added a note addressing not referencing the same audio file multiple times in the reading order

Feedback appreciated!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/pull/69.html" title="Last updated on Feb 12, 2020, 1:00 PM UTC (648560b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/69/c72b917...648560b.html" title="Last updated on Feb 12, 2020, 1:00 PM UTC (648560b)">Diff</a>