### PR TITLE
Changed 'behaviour' to 'behavior'

### DIFF
--- a/index.html
+++ b/index.html
@@ -823,16 +823,16 @@
 
 		</section>
 		<section id="audio-ua-behaviour" class="informative">
-			<h2>User Agent Behaviours for Audiobooks</h2>
+			<h2>User Agent Behaviors for Audiobooks</h2>
 
-			<p>This section outlines the expected user agent behaviours for implementation of audiobooks. For processing
+			<p>This section outlines the expected user agent behaviors for implementation of audiobooks. For processing
 				instructions, user agents should refer to the <a
 					href="https://www.w3.org/TR/pub-manifest/#manifest-processing"><code>Processing a
-					Manifest</code></a> section of the Publication Manifest specification, and conform to any behaviour
+					Manifest</code></a> section of the Publication Manifest specification, and conform to any behavior
 				described there.</p>
 
-			<p>All user agent behaviours described in this section are intended to provide implementors with guidance,
-				not strict requirements. Behaviours in this document are taken mainly from the <a
+			<p>All user agent behaviors described in this section are intended to provide implementors with guidance,
+				not strict requirements. Behaviors in this document are taken mainly from the <a
 					href="https://www.w3.org/TR/pwp-ucr/">Use Cases and Requirements</a> note published by the working
 				group.</p>
 
@@ -932,6 +932,7 @@
 					<li>3-Jan-2020: Extra step in <a href="#audio-manifest-processing"></a> adding the PEP’s URL to the
 						collection of unique resources in the manifest. See <a
 							href="https://github.com/w3c/publ-tests/issues/7">issue #7 for the test-suite</a>. </li>
+					<li>10-Feb-2020: The spelling of “behaviour” has been changed from British to US.</li>
 				</ul>
 				<p>For a complete list of issues addressed, refer to the <a
 						href="https://github.com/w3c/audiobooks/issues?q=is%3Aissue+is%3Aclosed+sort%3Aupdated-desc"


### PR DESCRIPTION
Alas! the W3C publication rules require US English spelling, so British is not o.k....


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/pull/74.html" title="Last updated on Feb 10, 2020, 2:38 PM UTC (64b87ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/74/e001d06...64b87ec.html" title="Last updated on Feb 10, 2020, 2:38 PM UTC (64b87ec)">Diff</a>