### PR TITLE
add audiobook schema

### DIFF
--- a/index.html
+++ b/index.html
@@ -960,6 +960,16 @@
 						version</a></h3>
 
 				<ul>
+					<li>2-July-2020: Added a note about the shape of the manifest being defined by the JSON schema to
+						the manifest introduction. See <a href="https://github.com/w3c/audiobooks/issues/71">issue
+							71</a>.</li>
+				</ul>
+			</section>
+
+			<section id="change-log-older">
+				<h3>Other substantive changes since Candidate Recommendation</h3>
+
+				<ul>
 					<li>12-Feb-2020: The algorithm step to check and compare resource durations to the total audiobook
 						duration was moved to avoid duplicate validity checks. The algorithm step to warn about the
 						primary entry page not being listed in the unique resources has been removed as it is no checked
@@ -971,13 +981,6 @@
 					<li>07-Feb-2020: The manifest requirements section was moved out of the properties section as it
 						also includes resource relations. See <a href="https://github.com/w3c/audiobooks/issues/70"
 							>issue 70</a>.</li>
-				</ul>
-			</section>
-
-			<section id="change-log-older">
-				<h3>Other substantive changes since Candidate Recommendation</h3>
-
-				<ul>
 					<li>03-Jan-2020: A new (informative) section <a href="#toc-algorithm-extension"></a> has been added
 						defining, the extension of the table of contents processing algorithm. See <a
 							href="https://github.com/w3c/audiobooks/issues/63">issue #63</a>. </li>

--- a/index.html
+++ b/index.html
@@ -159,6 +159,11 @@
 					Publication Manifest [[pub-manifest]]. Where these properties are extended from the Publication
 					Manifest is specified in this section.</p>
 
+				<p class="note">The Audiobook manifest is defined as a specific "shape" of [[json-ld11]]. This shape is
+					also defined, informally, through a JSON schema&#160;[[json-schema]] that expresses the constraints
+					defined in this specification. This schema is maintained at <a
+						href="https://github.com/w3c/audiobook/blob/master/schema/"
+						>https://github.com/w3c/audiobook/blob/master/schema/</a>.</p>
 			</section>
 
 			<section id="audio-requirements">
@@ -420,7 +425,10 @@
 					starting and ending points of those chapters in the larger audio file, as demonstrated in <a
 						href="#toc-mediafragments">this example</a>.</p>
 
-				<p class="note">Annotations can also use media fragments to identify the location of the annotation in the resource, and are compatible with the <a href="https://www.w3.org/TR/annotation-model/">Web Annotations</a> model. This method will only apply to audiobook manifests that are not packaged.</p>
+				<p class="note">Annotations can also use media fragments to identify the location of the annotation in
+					the resource, and are compatible with the <a href="https://www.w3.org/TR/annotation-model/">Web
+						Annotations</a> model. This method will only apply to audiobook manifests that are not
+					packaged.</p>
 
 				<pre class="example" title="Audiobook Reading Order for a Single Resource">
 							{
@@ -824,8 +832,8 @@
 				<li> If the <a>primary entry page</a> is available, then execute the algorithm locating the table of
 					content element on the primary entry page. </li>
 				<li> If the previous step is not successful, locate the relevant resource, if available, in the manifest
-					as described in <a data-cite="pub-manifest#contents">§&#160;4.8.1.3&#160;Table of
-						Contents</a> in [[pub-manifest]], and execute the same algorithm on that resource. </li>
+					as described in <a data-cite="pub-manifest#contents">§&#160;4.8.1.3&#160;Table of Contents</a> in
+					[[pub-manifest]], and execute the same algorithm on that resource. </li>
 			</ol>
 
 			<p>See also <a href="#audio-toc"></a> for further details.</p>

--- a/schema/README.md
+++ b/schema/README.md
@@ -10,7 +10,7 @@ The schema is updated to newer drafts as broad support in validators becomes ava
 
 The primary schema file `audiobooks.schema.json` requires the shared [component schemas](https://github.com/w3c/pub-manifest/tree/master/schema/) from the publication manifest repository. The `module` folder from that repository may need to be downloaded and placed in the same directory as the `audiobooks.schema.json` file depending on the validator used.
 
-In some cases, it may be possible to validate without downloading the physical schemas (i.e., if the validator can retrieve the schemas automatically). In these cases, only the URL `https://w3c.github.io/audiobook/schema/audiobooks.schema.json` needs to be specified.
+In some cases, it may be possible to validate without downloading the physical schemas (i.e., if the validator can retrieve the schemas automatically). In these cases, only the URL `https://w3c.github.io/audiobooks/schema/audiobooks.schema.json` needs to be specified.
 
 ## Validators
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,22 @@
+# Audiobooks Manifest Schema
+
+The schema in [this directory](https://github.com/w3c/audiobooks/tree/master/schema) is an adaptation of the publication manifest schemas for validating audiobook manifests. (Note, however, that not all constraints can be captured through the schemas.)
+
+The schema is written in [JSON Schema](https://json-schema.org/), and currently conform to **Draft-07**.
+
+The schema is updated to newer drafts as broad support in validators becomes available. 
+
+## Structure
+
+The primary schema file `audiobooks.schema.json` also requires and several [component schemas](https://github.com/w3c/audiobooks/tree/master/schema) from the publication manifest repository (currently all the json files except `publication.schema.json`). These schema files need to be downloaded and placed in the same directory.
+
+Only the primary schema file needs to be specified for validation, as the other files are automatically imported.
+
+## Validators
+
+A [list of JSON Schema validators](https://json-schema.org/implementations.html) and the draft(s) they support is available from the JSON Schema site.
+
+The audiobooks manifest schema is known to work with the following validators/tools:
+
+- [ajv-cli](https://github.com/jessedc/ajv-cli)
+- [Oxygen Editor](https://www.oxygenxml.com/)

--- a/schema/README.md
+++ b/schema/README.md
@@ -8,9 +8,9 @@ The schema is updated to newer drafts as broad support in validators becomes ava
 
 ## Structure
 
-The primary schema file `audiobooks.schema.json` also requires and several [component schemas](https://github.com/w3c/audiobooks/tree/master/schema) from the publication manifest repository (currently all the json files except `publication.schema.json`). These schema files need to be downloaded and placed in the same directory.
+The primary schema file `audiobooks.schema.json` also requires several [component schemas](https://github.com/w3c/audiobooks/tree/master/schema) from the publication manifest repository (currently all the json files except `publication.schema.json`). These schema files need to be downloaded and placed in the same directory.
 
-Only the primary schema file needs to be specified for validation, as the other files are automatically imported.
+Only the primary schema file needs to be specified for validation as the other files are automatically imported.
 
 ## Validators
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -8,9 +8,7 @@ The schema is updated to newer drafts as broad support in validators becomes ava
 
 ## Structure
 
-The primary schema file `audiobooks.schema.json` also requires several shared [component schemas](https://github.com/w3c/pub-manifest/tree/master/schema/) from the publication manifest repository. The `module` folder from that repository needs to be downloaded and placed in the same directory as the `audiobooks.schema.json` file.
-
-Only the `audiobook.schema.json` file needs to be specified for validation as the other files are automatically imported.
+The primary schema file `audiobooks.schema.json` also requires several shared [component schemas](https://github.com/w3c/pub-manifest/tree/master/schema/) from the publication manifest repository. The `module` folder from that repository may need to be downloaded and placed in the same directory as the `audiobooks.schema.json` file depending on the validator used.
 
 ## Validators
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -8,9 +8,9 @@ The schema is updated to newer drafts as broad support in validators becomes ava
 
 ## Structure
 
-The primary schema file `audiobooks.schema.json` also requires several [component schemas](https://github.com/w3c/audiobooks/tree/master/schema) from the publication manifest repository (currently all the json files except `publication.schema.json`). These schema files need to be downloaded and placed in the same directory.
+The primary schema file `audiobooks.schema.json` also requires several shared [component schemas](https://github.com/w3c/pub-manifest/tree/master/schema/) from the publication manifest repository. The `module` folder from that repository needs to be downloaded and placed in the same directory as the `audiobooks.schema.json` file.
 
-Only the primary schema file needs to be specified for validation as the other files are automatically imported.
+Only the `audiobook.schema.json` file needs to be specified for validation as the other files are automatically imported.
 
 ## Validators
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -8,7 +8,9 @@ The schema is updated to newer drafts as broad support in validators becomes ava
 
 ## Structure
 
-The primary schema file `audiobooks.schema.json` also requires several shared [component schemas](https://github.com/w3c/pub-manifest/tree/master/schema/) from the publication manifest repository. The `module` folder from that repository may need to be downloaded and placed in the same directory as the `audiobooks.schema.json` file depending on the validator used.
+The primary schema file `audiobooks.schema.json` requires the shared [component schemas](https://github.com/w3c/pub-manifest/tree/master/schema/) from the publication manifest repository. The `module` folder from that repository may need to be downloaded and placed in the same directory as the `audiobooks.schema.json` file depending on the validator used.
+
+In some cases, it may be possible to validate without downloading the physical schemas (i.e., if the validator can retrieve the schemas automatically). In these cases, only the URL `https://w3c.github.io/audiobook/schema/audiobooks.schema.json` needs to be specified.
 
 ## Validators
 

--- a/schema/audiobooks.schema.json
+++ b/schema/audiobooks.schema.json
@@ -44,9 +44,11 @@
 				{
 					"type": "array",
 					"items": {
-						"type": "string",
+						"type": "string"
+					},
+					"contains": {
 						"const": "https://www.w3.org/TR/audiobooks/"
-					}		
+					}
 				}
 			]
 		},

--- a/schema/audiobooks.schema.json
+++ b/schema/audiobooks.schema.json
@@ -202,7 +202,7 @@
 	"required": [
 		"@context",
 		"conformsTo",
-		"title",
+		"name",
 		"readingOrder"
 	]
 }

--- a/schema/audiobooks.schema.json
+++ b/schema/audiobooks.schema.json
@@ -5,7 +5,7 @@
 	"type": "object",
 	"properties": {
 		"@context": {
-			"$ref": "context.schema.json"
+			"$ref": "./module/context.schema.json"
 		},
 		"type": {
 			"oneOf": [
@@ -49,85 +49,85 @@
 			"type": "boolean"
 		},
 		"accessMode": {
-			"$ref": "strings.schema.json"
+			"$ref": "./module/strings.schema.json"
 		},
 		"accessModeSufficient": {
-			"$ref": "item-lists.schema.json"
+			"$ref": "./module/item-lists.schema.json"
 		},
 		"accessibilityFeature": {
-			"$ref": "strings.schema.json"
+			"$ref": "./module/strings.schema.json"
 		},
 		"accessibilityHazard": {
-			"$ref": "strings.schema.json"
+			"$ref": "./module/strings.schema.json"
 		},
 		"accessibilitySummary": {
-			"$ref": "localizable.schema.json"
+			"$ref": "./module/localizable.schema.json"
 		},
 		"artist": {
-			"$ref": "contributor.schema.json"
+			"$ref": "./module/contributor.schema.json"
 		},
 		"author": {
-			"$ref": "contributor.schema.json"
+			"$ref": "./module/contributor.schema.json"
 		},
 		"colorist": {
-			"$ref": "contributor.schema.json"
+			"$ref": "./module/contributor.schema.json"
 		},
 		"contributor": {
-			"$ref": "contributor.schema.json"
+			"$ref": "./module/contributor.schema.json"
 		},
 		"creator": {
-			"$ref": "contributor.schema.json"
+			"$ref": "./module/contributor.schema.json"
 		},
 		"editor": {
-			"$ref": "contributor.schema.json"
+			"$ref": "./module/contributor.schema.json"
 		},
 		"illustrator": {
-			"$ref": "contributor.schema.json"
+			"$ref": "./module/contributor.schema.json"
 		},
 		"inker": {
-			"$ref": "contributor.schema.json"
+			"$ref": "./module/contributor.schema.json"
 		},
 		"letterer": {
-			"$ref": "contributor.schema.json"
+			"$ref": "./module/contributor.schema.json"
 		},
 		"penciler": {
-			"$ref": "contributor.schema.json"
+			"$ref": "./module/contributor.schema.json"
 		},
 		"publisher": {
-			"$ref": "contributor.schema.json"
+			"$ref": "./module/contributor.schema.json"
 		},
 		"readBy": {
-			"$ref": "contributor.schema.json"
+			"$ref": "./module/contributor.schema.json"
 		},
 		"translator": {
-			"$ref": "contributor.schema.json"
+			"$ref": "./module/contributor.schema.json"
 		},
 		"url": {
-			"$ref": "urls.schema.json"
+			"$ref": "./module/urls.schema.json"
 		},
 		"duration": {
-			"$ref": "duration.schema.json"
+			"$ref": "./module/duration.schema.json"
 		},
 		"inLanguage": {
-			"$ref": "language.schema.json"
+			"$ref": "./module/language.schema.json"
 		},
 		"dateModified": {
-			"$ref": "date.schema.json"
+			"$ref": "./module/date.schema.json"
 		},
 		"datePublished": {
-			"$ref": "date.schema.json"
+			"$ref": "./module/date.schema.json"
 		},
 		"name": {
-			"$ref": "localizable.schema.json"
+			"$ref": "./module/localizable.schema.json"
 		},
 		"readingOrder": {
-			"$ref": "resource.categorization.schema.json"
+			"$ref": "./module/resource.categorization.schema.json"
 		},
 		"resources": {
-			"$ref": "resource.categorization.schema.json"
+			"$ref": "./module/resource.categorization.schema.json"
 		},
 		"links": {
-			"$ref": "resource.categorization.schema.json"
+			"$ref": "./module/resource.categorization.schema.json"
 		}
 	},
 	"required": [

--- a/schema/audiobooks.schema.json
+++ b/schema/audiobooks.schema.json
@@ -17,22 +17,22 @@
 			"additionalItems": true,
 			"uniqueItems": true
 		},
-        "type": {
-            "oneOf": [
-                {
-                    "type": "string",
-                    "const": "Audiobook"
-                },
-                {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "contains": {
-                        "const": "Audiobook"
-                    }
-                }
-            ],
+		"type": {
+			"oneOf": [
+				{
+					"type": "string",
+					"const": "Audiobook"
+				},
+				{
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"contains": {
+						"const": "Audiobook"
+					}
+				}
+			],
 			"uniqueItems": true
 		},
 		"conformsTo" : {

--- a/schema/audiobooks.schema.json
+++ b/schema/audiobooks.schema.json
@@ -1,0 +1,206 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "audiobooks.schema.json",
+	"title": "Audiobooks Manifest",
+	"type": "object",
+	"properties": {
+		"@context": {
+			"type": "array",
+			"items": [
+				{
+					"const": "https://schema.org"
+				},
+				{
+					"const": "https://www.w3.org/ns/pub-context"
+				}
+			],
+			"additionalItems": true,
+			"uniqueItems": true
+		},
+        "type": {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "const": "Audiobook"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "contains": {
+                        "const": "Audiobook"
+                    }
+                }
+            ],
+			"uniqueItems": true
+		},
+		"conformsTo" : {
+			"oneOf": [
+				{
+					"type": "string",
+					"const": "https://www.w3.org/TR/audiobooks/"
+				},
+				{
+					"type": "array",
+					"items": {
+						"type": "string",
+						"const": "https://www.w3.org/TR/audiobooks/"
+					}		
+				}
+			]
+		},
+		"id": {
+			"type": "string"
+		},
+		"abridged": {
+			"type": "boolean"
+		},
+		"accessMode": {
+			"type": [
+				"string",
+				"array"
+			],
+			"items": {
+				"type": "string"
+			},
+			"uniqueItems": true
+		},
+		"accessModeSufficient": {
+			"oneOf": [
+				{
+					"$ref": "ItemList.schema.json"
+				},
+				{
+					"type": "array",
+					"items": {
+						"$ref": "ItemList.schema.json"
+					},
+					"uniqueItems": true
+				}
+			]
+		},
+		"accessibilityFeature": {
+			"type": [
+				"string",
+				"array"
+			],
+			"items": {
+				"type": "string"
+			},
+			"uniqueItems": true
+		},
+		"accessibilityHazard": {
+			"type": [
+				"string",
+				"array"
+			],
+			"items": {
+				"type": "string"
+			},
+			"uniqueItems": true
+		},
+		"accessibilitySummary": {
+			"$ref": "localizable.schema.json"
+		},
+		"artist": {
+			"$ref": "contributor.schema.json"
+		},
+		"author": {
+			"$ref": "contributor.schema.json"
+		},
+		"colorist": {
+			"$ref": "contributor.schema.json"
+		},
+		"contributor": {
+			"$ref": "contributor.schema.json"
+		},
+		"creator": {
+			"$ref": "contributor.schema.json"
+		},
+		"editor": {
+			"$ref": "contributor.schema.json"
+		},
+		"illustrator": {
+			"$ref": "contributor.schema.json"
+		},
+		"inker": {
+			"$ref": "contributor.schema.json"
+		},
+		"letterer": {
+			"$ref": "contributor.schema.json"
+		},
+		"penciler": {
+			"$ref": "contributor.schema.json"
+		},
+		"publisher": {
+			"$ref": "contributor.schema.json"
+		},
+		"readBy": {
+			"$ref": "contributor.schema.json"
+		},
+		"translator": {
+			"$ref": "contributor.schema.json"
+		},
+		"url": {
+			"$ref": "url.schema.json"
+		},
+		"duration": {
+			"type": "string",
+			"pattern": "^P(?!$)((\\d+Y)|(\\d+\\.\\d+Y$))?((\\d+M)|(\\d+\\.\\d+M$))?((\\d+W)|(\\d+\\.\\d+W$))?((\\d+D)|(\\d+\\.\\d+D$))?(T(?=\\d)((\\d+H)|(\\d+\\.\\d+H$))?((\\d+M)|(\\d+\\.\\d+M$))?(\\d+(\\.\\d+)?S)?)??$"
+		},
+		"inLanguage": {
+			"oneOf": [
+				{
+					"$ref": "bcp.schema.json"
+				},
+				{
+					"type": "array",
+					"items": {
+						"$ref": "bcp.schema.json"
+					}		
+				}
+			]
+		},
+		"dateModified": {
+			"type": "string",
+			"anyOf": [
+				{
+					"format": "date"
+				},
+				{
+					"format": "date-time"
+				}
+			]
+		},
+		"datePublished": {
+			"type": "string",
+			"anyOf": [
+				{
+					"format": "date"
+				},
+				{
+					"format": "date-time"
+				}
+			]
+		},
+		"name": {
+			"$ref": "localizable.schema.json"
+		},
+		"readingOrder": {
+			"$ref": "resource.categorization.schema.json"
+		},
+		"resources": {
+			"$ref": "resource.categorization.schema.json"
+		},
+		"links": {
+			"$ref": "resource.categorization.schema.json"
+		}
+	},
+	"required": [
+		"@context",
+		"conformsTo",
+		"title",
+		"readingOrder"
+	]
+}

--- a/schema/audiobooks.schema.json
+++ b/schema/audiobooks.schema.json
@@ -1,11 +1,11 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "audiobooks.schema.json",
+	"$id": "https://w3c.github.io/audiobook/schema/audiobooks.schema.json",
 	"title": "Audiobooks Manifest",
 	"type": "object",
 	"properties": {
 		"@context": {
-			"$ref": "./module/context.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/context.schema.json"
 		},
 		"type": {
 			"oneOf": [
@@ -49,85 +49,85 @@
 			"type": "boolean"
 		},
 		"accessMode": {
-			"$ref": "./module/strings.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/strings.schema.json"
 		},
 		"accessModeSufficient": {
-			"$ref": "./module/item-lists.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/item-lists.schema.json"
 		},
 		"accessibilityFeature": {
-			"$ref": "./module/strings.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/strings.schema.json"
 		},
 		"accessibilityHazard": {
-			"$ref": "./module/strings.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/strings.schema.json"
 		},
 		"accessibilitySummary": {
-			"$ref": "./module/localizable.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/localizable.schema.json"
 		},
 		"artist": {
-			"$ref": "./module/contributor.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"author": {
-			"$ref": "./module/contributor.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"colorist": {
-			"$ref": "./module/contributor.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"contributor": {
-			"$ref": "./module/contributor.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"creator": {
-			"$ref": "./module/contributor.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"editor": {
-			"$ref": "./module/contributor.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"illustrator": {
-			"$ref": "./module/contributor.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"inker": {
-			"$ref": "./module/contributor.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"letterer": {
-			"$ref": "./module/contributor.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"penciler": {
-			"$ref": "./module/contributor.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"publisher": {
-			"$ref": "./module/contributor.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"readBy": {
-			"$ref": "./module/contributor.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"translator": {
-			"$ref": "./module/contributor.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"url": {
-			"$ref": "./module/urls.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/urls.schema.json"
 		},
 		"duration": {
-			"$ref": "./module/duration.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/duration.schema.json"
 		},
 		"inLanguage": {
-			"$ref": "./module/language.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/language.schema.json"
 		},
 		"dateModified": {
-			"$ref": "./module/date.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/date.schema.json"
 		},
 		"datePublished": {
-			"$ref": "./module/date.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/date.schema.json"
 		},
 		"name": {
-			"$ref": "./module/localizable.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/localizable.schema.json"
 		},
 		"readingOrder": {
-			"$ref": "./module/resource.categorization.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/resource.categorization.schema.json"
 		},
 		"resources": {
-			"$ref": "./module/resource.categorization.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/resource.categorization.schema.json"
 		},
 		"links": {
-			"$ref": "./module/resource.categorization.schema.json"
+			"$ref": "https://w3c.github.io/pub-manifest/schema/module/resource.categorization.schema.json"
 		}
 	},
 	"required": [

--- a/schema/audiobooks.schema.json
+++ b/schema/audiobooks.schema.json
@@ -5,17 +5,7 @@
 	"type": "object",
 	"properties": {
 		"@context": {
-			"type": "array",
-			"items": [
-				{
-					"const": "https://schema.org"
-				},
-				{
-					"const": "https://www.w3.org/ns/pub-context"
-				}
-			],
-			"additionalItems": true,
-			"uniqueItems": true
+			"$ref": "context.schema.json"
 		},
 		"type": {
 			"oneOf": [
@@ -59,48 +49,16 @@
 			"type": "boolean"
 		},
 		"accessMode": {
-			"type": [
-				"string",
-				"array"
-			],
-			"items": {
-				"type": "string"
-			},
-			"uniqueItems": true
+			"$ref": "strings.schema.json"
 		},
 		"accessModeSufficient": {
-			"oneOf": [
-				{
-					"$ref": "ItemList.schema.json"
-				},
-				{
-					"type": "array",
-					"items": {
-						"$ref": "ItemList.schema.json"
-					},
-					"uniqueItems": true
-				}
-			]
+			"$ref": "item-lists.schema.json"
 		},
 		"accessibilityFeature": {
-			"type": [
-				"string",
-				"array"
-			],
-			"items": {
-				"type": "string"
-			},
-			"uniqueItems": true
+			"$ref": "strings.schema.json"
 		},
 		"accessibilityHazard": {
-			"type": [
-				"string",
-				"array"
-			],
-			"items": {
-				"type": "string"
-			},
-			"uniqueItems": true
+			"$ref": "strings.schema.json"
 		},
 		"accessibilitySummary": {
 			"$ref": "localizable.schema.json"
@@ -145,46 +103,19 @@
 			"$ref": "contributor.schema.json"
 		},
 		"url": {
-			"$ref": "url.schema.json"
+			"$ref": "urls.schema.json"
 		},
 		"duration": {
-			"type": "string",
-			"pattern": "^P(?!$)((\\d+Y)|(\\d+\\.\\d+Y$))?((\\d+M)|(\\d+\\.\\d+M$))?((\\d+W)|(\\d+\\.\\d+W$))?((\\d+D)|(\\d+\\.\\d+D$))?(T(?=\\d)((\\d+H)|(\\d+\\.\\d+H$))?((\\d+M)|(\\d+\\.\\d+M$))?(\\d+(\\.\\d+)?S)?)??$"
+			"$ref": "duration.schema.json"
 		},
 		"inLanguage": {
-			"oneOf": [
-				{
-					"$ref": "bcp.schema.json"
-				},
-				{
-					"type": "array",
-					"items": {
-						"$ref": "bcp.schema.json"
-					}		
-				}
-			]
+			"$ref": "language.schema.json"
 		},
 		"dateModified": {
-			"type": "string",
-			"anyOf": [
-				{
-					"format": "date"
-				},
-				{
-					"format": "date-time"
-				}
-			]
+			"$ref": "date.schema.json"
 		},
 		"datePublished": {
-			"type": "string",
-			"anyOf": [
-				{
-					"format": "date"
-				},
-				{
-					"format": "date-time"
-				}
-			]
+			"$ref": "date.schema.json"
 		},
 		"name": {
 			"$ref": "localizable.schema.json"


### PR DESCRIPTION
Adds a new primary driver file that expects the Audiobooks type, audiobooks conformsTo URL and requires title and readingOrder.

I haven't added all the component files, as it seems like a nuisance to maintain them in two places. I've instead noted in the readme they have to be downloaded. Always open to changing that, though.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/pull/81.html" title="Last updated on Jul 3, 2020, 3:00 PM UTC (9a79c7a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/81/9b2df26...9a79c7a.html" title="Last updated on Jul 3, 2020, 3:00 PM UTC (9a79c7a)">Diff</a>