### PR TITLE
Update schema urls to w3c address

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,8 +162,8 @@
 				<p class="note">The Audiobook manifest is defined as a specific "shape" of [[json-ld11]]. This shape is
 					also defined, informally, through a JSON schema&#160;[[json-schema]] that expresses the constraints
 					defined in this specification. This schema is maintained at <a
-						href="https://www.w3.org/ns/audiobooks/schema/"
-					>https://www.w3.org/ns/audiobooks/schema/</a>.</p>
+						href="https://www.w3.org/ns/pub-schema/audiobooks/"
+					>https://www.w3.org/ns/pub-schema/audiobooks/</a>.</p>
 			</section>
 
 			<section id="audio-requirements">

--- a/index.html
+++ b/index.html
@@ -162,8 +162,8 @@
 				<p class="note">The Audiobook manifest is defined as a specific "shape" of [[json-ld11]]. This shape is
 					also defined, informally, through a JSON schema&#160;[[json-schema]] that expresses the constraints
 					defined in this specification. This schema is maintained at <a
-						href="https://github.com/w3c/audiobook/blob/master/schema/"
-						>https://github.com/w3c/audiobook/blob/master/schema/</a>.</p>
+						href="https://www.w3.org/ns/audiobooks/schema/"
+					>https://www.w3.org/ns/audiobooks/schema/</a>.</p>
 			</section>
 
 			<section id="audio-requirements">
@@ -978,6 +978,9 @@
 						version</a></h3>
 
 				<ul>
+					<li>27-July-2020: Updated the reference schema URL to a W3C address. See <a
+							href="https://github.com/w3c/pub-manifest/issues/226">issue 226 in Publication
+						Manifest</a>.</li>
 					<li>2-July-2020: Added a note about the shape of the manifest being defined by the JSON schema to
 						the manifest introduction. See <a href="https://github.com/w3c/audiobooks/issues/71">issue
 							71</a>.</li>

--- a/schema/README.md
+++ b/schema/README.md
@@ -10,7 +10,7 @@ The schema is updated to newer drafts as broad support in validators becomes ava
 
 The primary schema file `audiobooks.schema.json` requires the shared [component schemas](https://github.com/w3c/pub-manifest/tree/master/schema/) from the publication manifest repository. The `module` folder from that repository may need to be downloaded and placed in the same directory as the `audiobooks.schema.json` file depending on the validator used.
 
-In some cases, it may be possible to validate without downloading the physical schemas (i.e., if the validator can retrieve the schemas automatically). In these cases, only the URL `https://www.w3.org/ns/audiobooks/schema/audiobooks.schema.json` needs to be specified.
+In some cases, it may be possible to validate without downloading the physical schemas (i.e., if the validator can retrieve the schemas automatically). In these cases, only the URL `https://www.w3.org/ns/pub-schema/audiobooks/audiobooks.schema.json` needs to be specified.
 
 ## Validators
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -10,7 +10,7 @@ The schema is updated to newer drafts as broad support in validators becomes ava
 
 The primary schema file `audiobooks.schema.json` requires the shared [component schemas](https://github.com/w3c/pub-manifest/tree/master/schema/) from the publication manifest repository. The `module` folder from that repository may need to be downloaded and placed in the same directory as the `audiobooks.schema.json` file depending on the validator used.
 
-In some cases, it may be possible to validate without downloading the physical schemas (i.e., if the validator can retrieve the schemas automatically). In these cases, only the URL `https://w3c.github.io/audiobooks/schema/audiobooks.schema.json` needs to be specified.
+In some cases, it may be possible to validate without downloading the physical schemas (i.e., if the validator can retrieve the schemas automatically). In these cases, only the URL `https://www.w3.org/ns/audiobooks/schema/audiobooks.schema.json` needs to be specified.
 
 ## Validators
 

--- a/schema/audiobooks.schema.json
+++ b/schema/audiobooks.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://w3c.github.io/audiobook/schema/audiobooks.schema.json",
+	"$id": "https://www.w3.org/ns/audiobooks/schema/audiobooks.schema.json",
 	"title": "Audiobooks Manifest",
 	"type": "object",
 	"properties": {

--- a/schema/audiobooks.schema.json
+++ b/schema/audiobooks.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://www.w3.org/ns/audiobooks/schema/audiobooks.schema.json",
+	"$id": "https://www.w3.org/ns/pub-schema/audiobooks/audiobooks.schema.json",
 	"title": "Audiobooks Manifest",
 	"type": "object",
 	"properties": {

--- a/schema/audiobooks.schema.json
+++ b/schema/audiobooks.schema.json
@@ -5,7 +5,7 @@
 	"type": "object",
 	"properties": {
 		"@context": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/context.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/context.schema.json"
 		},
 		"type": {
 			"oneOf": [
@@ -49,85 +49,85 @@
 			"type": "boolean"
 		},
 		"accessMode": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/strings.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/strings.schema.json"
 		},
 		"accessModeSufficient": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/item-lists.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/item-lists.schema.json"
 		},
 		"accessibilityFeature": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/strings.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/strings.schema.json"
 		},
 		"accessibilityHazard": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/strings.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/strings.schema.json"
 		},
 		"accessibilitySummary": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/localizable.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/localizable.schema.json"
 		},
 		"artist": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"author": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"colorist": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"contributor": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"creator": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"editor": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"illustrator": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"inker": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"letterer": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"penciler": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"publisher": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"readBy": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"translator": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"url": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/urls.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/urls.schema.json"
 		},
 		"duration": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/duration.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/duration.schema.json"
 		},
 		"inLanguage": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/language.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/language.schema.json"
 		},
 		"dateModified": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/date.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/date.schema.json"
 		},
 		"datePublished": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/date.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/date.schema.json"
 		},
 		"name": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/localizable.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/localizable.schema.json"
 		},
 		"readingOrder": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/resource.categorization.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/resource.categorization.schema.json"
 		},
 		"resources": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/resource.categorization.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/resource.categorization.schema.json"
 		},
 		"links": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/resource.categorization.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/resource.categorization.schema.json"
 		}
 	},
 	"required": [


### PR DESCRIPTION
As [resolved on the telecon today](https://www.w3.org/publishing/groups/publ-wg/Meetings/Minutes/2020/2020-07-27-pwg), updating the URLs to w3c addresses to fix https://github.com/w3c/pub-manifest/issues/226.

Same as with the other PR, we'll need to make sure the redirects are up and running before merging.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/pull/85.html" title="Last updated on Jul 29, 2020, 10:20 PM UTC (114a5b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/85/ba8af37...114a5b6.html" title="Last updated on Jul 29, 2020, 10:20 PM UTC (114a5b6)">Diff</a>