### PR TITLE
Changed wp-context to pub-context

### DIFF
--- a/experiments/flatland.json
+++ b/experiments/flatland.json
@@ -1,5 +1,5 @@
 {
-  "@context": ["https://schema.org", "https://www.w3.org/ns/wp-context"],
+  "@context": ["https://schema.org", "https://www.w3.org/ns/pub-context"],
   "conformsTo" : "https://www.w3.org/TR/audiobooks/",
   "type": "Audiobook",
   "id": "https://librivox.org/flatland-a-romance-of-many-dimensions-by-edwin-abbott-abbott/",

--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@
 					term&#160;[[!pub-manifest]].</p>
 
 				<pre class="example" title="Setting a publication's type to Audiobook.">{
-    "@context" : ["https://schema.org", "https://www.w3.org/ns/wp-context"],
+    "@context" : ["https://schema.org", "https://www.w3.org/ns/pub-context"],
     "type"     : "Audiobook"
     …
 }</pre>


### PR DESCRIPTION
There was two leftover `wp-context` usage in the examples... Changed them to `pub-context`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/pull/86.html" title="Last updated on Jul 28, 2020, 7:20 AM UTC (6546e7b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/86/ba8af37...6546e7b.html" title="Last updated on Jul 28, 2020, 7:20 AM UTC (6546e7b)">Diff</a>