### PR TITLE
clarify primary entry page requirement

### DIFF
--- a/index.html
+++ b/index.html
@@ -934,7 +934,7 @@
 
 				<ul>
 					<li>8-Sept-2020: Clarfied that the primary entry page is only required when the packaging does
-						provide an alternative method. See <a href="https://github.com/w3c/audiobooks/issues/61">issue
+						not provide an alternative method. See <a href="https://github.com/w3c/audiobooks/issues/61">issue
 							61</a>.</li>
 					<li>26-Aug-2020: Removed the example of synchronized narration and updated reference to the work of
 						the Synchronized Multimedia for Publications Community Group to reflect the early nature of that

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 				wgURI: "https://www.w3.org/publishing/groups/publ-wg/",
 				wgPublicList: "public-publ-wg",
 				edDraftURI: "https://w3c.github.io/audiobooks/",
-				errata:     "https://w3c.github.io/audiobooks/errata/",
+				errata: "https://w3c.github.io/audiobooks/errata/",
 				previousPublishDate: "2020-07-30",
 				previousMaturity: "CR",
 				specStatus: "ED",
@@ -97,16 +97,19 @@
 			<section id="audio-pep">
 				<h3>Primary Entry Page</h3>
 
-				<p>The <dfn>primary entry page</dfn> represents the preferred starting <a href="#audio-resourcelist"
-						>resource</a> for an Audiobook and enables discovery of its manifest.</p>
+				<p>The <dfn>primary entry page</dfn> is an HTML <a href="#audio-resourcelist">resource</a> that
+					represents the preferred starting resource of an Audiobook and enables discovery of its manifest. It
+					typically introduces the audiobook and provides access to the content.</p>
 
-				<p>The primary entry page is an HTML resource that typically introduces the audiobook and provides
-					access to the content. It SHOULD contain the <a href="#audio-toc">table of contents</a>.</p>
+				<p>The primary entry page MUST include either a <a
+						href="https://www.w3.org/TR/pub-manifest/#manifest-link">link to the manifest</a> or <a
+						href="https://www.w3.org/TR/pub-manifest/#manifest-embed">embed the manifest</a>
+					[[!pub-manifest]]. It also SHOULD contain the <a href="#audio-toc">table of contents</a>.</p>
 
-				<p>It is not required that the primary entry page be included in the <a href="#audio-readingorder"
-						>default reading order</a>, as the Audiobooks profile requires that only audio resources be
-					present. The primary entry page should instead, if present, be included as a <a
-						href="#audio-resourcelist">resource</a>.</p>
+				<p>An Audiobook MUST include a primary entry page except when <a
+						href="https://www.w3.org/TR/audiobooks/#audio-packaging">packaging</a> allows alternative
+					discovery of the manifest. When present, the page MUST be included in the <a
+						href="#audio-resourcelist">resource list</a>.</p>
 			</section>
 
 			<section id="audio-toc">
@@ -930,6 +933,9 @@
 						version</a></h3>
 
 				<ul>
+					<li>8-Sept-2020: Clarfied that the primary entry page is only required when the packaging does
+						provide an alternative method. See <a href="https://github.com/w3c/audiobooks/issues/61">issue
+							61</a>.</li>
 					<li>26-Aug-2020: Removed the example of synchronized narration and updated reference to the work of
 						the Synchronized Multimedia for Publications Community Group to reflect the early nature of that
 						work. See <a href="https://github.com/w3c/audiobooks/issues/87">issue 87</a>.</li>


### PR DESCRIPTION
Fixes #61 by adding the prose suggested in https://github.com/w3c/audiobooks/issues/61#issuecomment-687312361


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/pull/90.html" title="Last updated on Sep 8, 2020, 12:20 PM UTC (42372ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/90/c8d01b5...42372ae.html" title="Last updated on Sep 8, 2020, 12:20 PM UTC (42372ae)">Diff</a>