### PR TITLE
Move id attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -620,8 +620,8 @@
 				<dd>
 					<p>The following <a href="https://www.w3.org/TR/pub-manifest/#processing-extension">extension
 							steps</a> are added for Audiobook manifests:</p>
-					<ol id="processing-toc">
-						<li>
+					<ol>
+						<li id="processing-toc">
 							<p>(<a href="#audio-pep"></a> and <a href="#audio-toc"></a>) If <var>document</var> is not
 								defined or does not include an [[!html]] element with the role <code>doc-toc</code>:</p>
 							<ol>


### PR DESCRIPTION
Currently, the `#processing-toc` is on the `<ol>` element which includes the following section (`#processing-duration`) as well.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/naglis/audiobooks/pull/98.html" title="Last updated on Sep 13, 2020, 12:48 AM UTC (ab5cb81)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/98/bc1bcd1...naglis:ab5cb81.html" title="Last updated on Sep 13, 2020, 12:48 AM UTC (ab5cb81)">Diff</a>