### PR TITLE
Updating TOC section to reflect changes

### DIFF
--- a/experiments/flatland.json
+++ b/experiments/flatland.json
@@ -30,47 +30,47 @@
     {
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_1_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "duration": 1371,
+      "duration": "PT1371S",
       "name": "Part 1, Sections 1 - 3"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_2_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "duration": 1669,
+      "duration": "PT1669S",
       "name": "Part 1, Sections 4 - 5"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_3_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "duration": 1506,
+      "duration": "PT1506S",
       "name": "Part 1, Sections 6 - 7"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_4_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "duration": 1669,
+      "duration": "PT1669S",
       "name": "Part 1, Sections 8 - 10"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_5_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "duration": 1506,
+      "duration": "PT1506S",
       "name": "Part 1, Sections 11 - 12"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_6_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "duration": 1798,
+      "duration": "PT1798S",
       "name": "Part 2, Sections 13 - 14"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_7_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "duration": 1225,
+      "duration": "PT1225S",
       "name": "Part 2, Sections 15 - 17"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_8_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "duration": 1371,
+      "duration": "PT1371S",
       "name": "Part 2, Sections 18 - 20"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_9_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "duration": 1659,
+      "duration": "PT1659S",
       "name": "Part 2, Sections 21 - 22"
     }
   ]

--- a/index.html
+++ b/index.html
@@ -442,7 +442,7 @@
 							Manifest</a> [[!pub-manifest]].</p>
 
 					<p>Duration SHOULD be expressed for the entirety of the audiobook as part of the manifest, and
-						SHOULD be present at the item level in the <a href="#audio-readingorder">default reading
+						MUST be present at the item level in the <a href="#audio-readingorder">default reading
 							order</a>.</p>
 
 					<p>When a content creator specifies both the duration for the audiobook and item-level duration in
@@ -482,6 +482,8 @@
 				<p>An audio resource can be referenced in its entirety via a URL [[url]], or for content where multiple
 					chapters occupy a single file by using <a href="https://www.w3.org/TR/media-frags/">media
 						fragments</a> [[media-frags]] to locate the exact starting and end points.</p>
+
+						<p class="issue" data-number="110">There is a proposed solution for this issue, that we remove fragment identifiers from <code>url</code> properties. However, this poses an issue for the scenario where a single audio file contains multiple chapters of content. A possible solution for this is the requirement of the <a href="#audio-toc">Table of Contents</a>, but more discussion is required.</p>
 
 				<p class="note">It is important to note that a resource cannot be referenced more than once in the
 					reading order. In the case where an audio file represents the content of multiple chapters or
@@ -1136,6 +1138,18 @@
 				&lt;/nav>
 				</pre>
 			</section>
+		</section>
+		<section id="change-log" class="appendix informative"> 
+			<h2>Change Log</h2>
+
+			<p>This change log identifies substantive changes since the publication of Audiobooks on Nov 10, 2020.</p>
+
+			<p>For a list of all issues addressed during maintenance, refer to the <a href="https://www.github.com/w3c/audiobooks/issues">Working Group's issue tracker</a>.</p>
+		
+			<ul>
+				<li>19-Jan-2022: Duration for items in the reading order is now a MUST, see <a href="https://www.github.com/w3c/audiobooks/issues/108">issue 108</a>.</li>
+				<li>19-Jan-2022: Corrected a syntax error in the <a href="#audio-simple">simple audiobook</a> sample file, see <a href="https://www.github.com/w3c/audiobooks/issues/109">issue 109</a>.</li>
+			</ul>
 		</section>
 		<div data-include="common/html/acknowledgements.html" data-include-replace="true"></div>
 	</body>

--- a/index.html
+++ b/index.html
@@ -479,15 +479,11 @@
 							><code>LinkedResource</code></a> [[!pub-manifest]]. The default reading order MUST NOT
 					contain non-audio resources.</p>
 
-				<p>An audio resource can be referenced in its entirety via a URL [[url]], or for content where multiple
-					chapters occupy a single file by using <a href="https://www.w3.org/TR/media-frags/">media
-						fragments</a> [[media-frags]] to locate the exact starting and end points.</p>
-
-						<p class="issue" data-number="110">There is a proposed solution for this issue, that we remove fragment identifiers from <code>url</code> properties. However, this poses an issue for the scenario where a single audio file contains multiple chapters of content. A possible solution for this is the requirement of the <a href="#audio-toc">Table of Contents</a>, but more discussion is required.</p>
+				<p>An audio resource MUST be referenced in its entirety via a URL [[url]].</p>
 
 				<p class="note">It is important to note that a resource cannot be referenced more than once in the
 					reading order. In the case where an audio file represents the content of multiple chapters or
-					sections of the book, the <a href="#audio-toc">table of contents</a> can be used to specify the
+					sections of the book, the <a href="#audio-toc">table of contents</a> should be used to specify the
 					starting and ending points of those chapters in the larger audio file, as demonstrated in <a
 						href="#toc-mediafragments">this example</a>.</p>
 
@@ -978,6 +974,7 @@
 			<p>Substantive changes since <a href="https://www.w3.org/TR/audiobooks">Recommendation</a> publication.</p>
 
 			<ul>
+				<li>16-Feb-2022: To address <a href="https://www.github.com/w3c/audiobooks/issues/110">issue 110</a>, media fragments can no longer be used in the <code>url</code> property in the Reading Order.</li>
 				<li>19-Jan-2022: Duration for items in the reading order is now a MUST, see <a href="https://www.github.com/w3c/audiobooks/issues/108">issue 108</a>.</li>
 				<li>19-Jan-2022: Corrected a syntax error in the <a href="#audio-simple">simple audiobook</a> sample file, see <a href="https://www.github.com/w3c/audiobooks/issues/109">issue 109</a>.</li>
 			</ul>
@@ -1097,14 +1094,14 @@
 				&lt;/head&gt;
 				&lt;body&gt;
 				    &#8230;
-				    &lt;section role="doc-toc"&gt;
+				    &lt;nav role="doc-toc"&gt;
 				        &lt;ol>
 				            &lt;li>&lt;a href="audio/chapter001.wav">Chapter 1. There was no possibility of taking a walk that day...&lt;/a>&lt;/li>
 				            &lt;li>&lt;a href="audio/chapter002.wav">Chapter 2. I resisted all the way:...&lt;/a>&lt;/li>
 				            &lt;li>&lt;a href="audio/chapter003.wav">Chapter 3. The next thing I remember is,...&lt;/a>&lt;/li>
 				            &#8230;
 			          &lt;/ol>
-				    &lt;/section&gt;
+				    &lt;/nav&gt;
 				    &#8230;
 				&lt;/body&gt;
 					</pre>

--- a/index.html
+++ b/index.html
@@ -975,12 +975,17 @@
 		<section id="change-log">
 			<h2>Change Log</h2>
 
-			<p>Substantive changes since the <a href="https://www.w3.org/TR/2019/WD-audiobooks-20190620/">First Public
-					Working Draft</a>:</p>
+			<p>Substantive changes since <a href="https://www.w3.org/TR/audiobooks">Recommendation</a> publication.</p>
 
 			<ul>
 				<li>19-Jan-2022: Duration for items in the reading order is now a MUST, see <a href="https://www.github.com/w3c/audiobooks/issues/108">issue 108</a>.</li>
 				<li>19-Jan-2022: Corrected a syntax error in the <a href="#audio-simple">simple audiobook</a> sample file, see <a href="https://www.github.com/w3c/audiobooks/issues/109">issue 109</a>.</li>
+			</ul>
+
+			<p>Substantive changes since the <a href="https://www.w3.org/TR/2019/WD-audiobooks-20190620/">First Public
+					Working Draft</a>:</p>
+
+			<ul>
 				<li>14-Sept-2020: Added a note that informative information about the table of contents structure and
 					formatting information is available in the Publication Manifest specification. See <a
 						href="https://github.com/w3c/audiobooks/issues/97">issue 97</a>.</li>

--- a/index.html
+++ b/index.html
@@ -445,6 +445,11 @@
 						MUST be present at the item level in the <a href="#audio-readingorder">default reading
 							order</a>.</p>
 
+						<div class="proposed correction">
+							<span class="marker">Proposed Correction 1.1</span>
+							<p>We have updated the normative requirement for the duration property on the item level, to address implementer feedback in regards to facilitating streaming. This normative requirement is now a MUST.</p>
+						</div>
+
 					<p>When a content creator specifies both the duration for the audiobook and item-level duration in
 						the <a href="#audio-readingorder">default reading order</a> the resource-level duration SHOULD
 						be equal to the sum of the durations of the items in the reading order.</p>
@@ -486,6 +491,11 @@
 					sections of the book, the <a href="#audio-toc">table of contents</a> should be used to specify the
 					starting and ending points of those chapters in the larger audio file, as demonstrated in <a
 						href="#toc-mediafragments">this example</a>.</p>
+					
+					<div class="proposed correction">
+						<span class="marker">Proposed Correction 1.1</span>
+						<p>Update previously non-normative statement about the use of media fragments to allow for referencing of audio files that span multiple chapters. The previous statement contradicted the note on referencing an audio file more than once in the reading order. The new normative statement will require that media fragments not be used on the <code>url</code> property in the Reading Order.</p>
+					</div>
 
 				<p class="note">Annotations can also use media fragments to identify the location of the annotation in
 					the resource, and are compatible with the <a href="https://www.w3.org/TR/annotation-model/">Web
@@ -507,29 +517,6 @@
 							    }]
 							}
 					</pre>
-
-				<pre class="example" title="Audiobook Reading Order for Multiple Resources using Media Fragments">
-							{
-							    "@context" : ["https://schema.org", "https://www.w3.org/ns/pub-context"],
-							    "conformsTo" : "https://www.w3.org/TR/audiobooks/",
-							    "url" : "https://publisher.example.org/janeeyre",
-							    "name" : "Jane Eyre",
-							    "readingOrder" : [{
-							        "type": "LinkedResource",
-							        "url" : "audio/part001.wav#t=0,457.931",
-							        "encodingFormat" : "audio/vnd-wav",
-							        "name" : "Chapter 1",
-							        "duration" : "PT457.931S"
-							    }, {
-							        "type" : "LinkedResource",
-							        "url" : "audio/part002.wav#t=12.741",
-							        "encodingFormat" : "audio/vnd-wav",
-							        "name" : "Chapter 2",
-							        "duration" : "PT234.245S"
-							    }]
-							}
-						</pre>
-
 			</section>
 
 			<section id="audio-resourcelist">

--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
 				<p>If the table of contents is not located in the <a href="#audio-pep">primary entry page</a>, the
 					manifest SHOULD identify the resource that contains the structure.</p>
 
-				<p>When an Audiobook contains additional resources (i.e. supplemental content):</p>
+				<p>When an Audiobook contains audio resources that include multiple chapters or parts, or if the audiobook contains supplemental content:</p>
 
 				<ul>
 					<li>
@@ -149,6 +149,8 @@
 								>publication resources</a>&#160;[[!pub-manifest]].</p>
 					</li>
 				</ul>
+
+				<p class="note">Some Audiobooks may have audio resources that contain more than one chapter or section of the book content. It is strongly recommended that content creators provide a table of contents using <a href="https://www.w3.org/TR/media-frags/">media fragments</a> [[media-frags]] to provide the user with access to the structure of the Audiobook.</p>
 
 				<p class="note">When including supplemental content, be aware that users might not have access to this
 					content unless it is linked to from the table of contents. It is strongly advised to provide links

--- a/index.html
+++ b/index.html
@@ -979,6 +979,8 @@
 					Working Draft</a>:</p>
 
 			<ul>
+				<li>19-Jan-2022: Duration for items in the reading order is now a MUST, see <a href="https://www.github.com/w3c/audiobooks/issues/108">issue 108</a>.</li>
+				<li>19-Jan-2022: Corrected a syntax error in the <a href="#audio-simple">simple audiobook</a> sample file, see <a href="https://www.github.com/w3c/audiobooks/issues/109">issue 109</a>.</li>
 				<li>14-Sept-2020: Added a note that informative information about the table of contents structure and
 					formatting information is available in the Publication Manifest specification. See <a
 						href="https://github.com/w3c/audiobooks/issues/97">issue 97</a>.</li>
@@ -1138,18 +1140,6 @@
 				&lt;/nav>
 				</pre>
 			</section>
-		</section>
-		<section id="change-log" class="appendix informative"> 
-			<h2>Change Log</h2>
-
-			<p>This change log identifies substantive changes since the publication of Audiobooks on Nov 10, 2020.</p>
-
-			<p>For a list of all issues addressed during maintenance, refer to the <a href="https://www.github.com/w3c/audiobooks/issues">Working Group's issue tracker</a>.</p>
-		
-			<ul>
-				<li>19-Jan-2022: Duration for items in the reading order is now a MUST, see <a href="https://www.github.com/w3c/audiobooks/issues/108">issue 108</a>.</li>
-				<li>19-Jan-2022: Corrected a syntax error in the <a href="#audio-simple">simple audiobook</a> sample file, see <a href="https://www.github.com/w3c/audiobooks/issues/109">issue 109</a>.</li>
-			</ul>
 		</section>
 		<div data-include="common/html/acknowledgements.html" data-include-replace="true"></div>
 	</body>


### PR DESCRIPTION
To better reflect the importance of the TOC in light of the change in PR #111 and issue #110, I am updating the language in the TOC section, and adding a note. This is to clarify that in the event of audio files containing more than one chapter/section, the TOC should be used to display that granularity. 

Feel free to offer editorial advice, it is much needed.

There were some (temporary) problems with Preview, so it could not work on this PR. Here is a preview/diff pair; it is slow but can help to review this:

- See [preview](https://labs.w3.org/spec-generator/?type=respec&url=https://cdn.statically.io/gh/w3c/audiobooks/toc-note/index.html)
- See [diff document](https://tinyurl.com/y7vsb2ep)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/pull/112.html" title="Last updated on Feb 17, 2022, 2:48 PM UTC (4f87254)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/audiobooks/112/ceb65ec...4f87254.html" title="Last updated on Feb 17, 2022, 2:48 PM UTC (4f87254)">Diff</a>