### PR TITLE
Fix error in "Commit history" link

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 				diffTool: "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
 				github: {
 					repoURL: "https://github.com/w3c/audiobooks",
-					branch: "master"
+					branch: "main"
 				},
 				localBiblio: localBiblio,
 				alternateFormats: [{


### PR DESCRIPTION
The "Commit history" link of the recommendation (current version at https://www.w3.org/TR/2020/REC-audiobooks-20201110/) points to https://github.com/w3c/audiobooks/commits/master. However, the 'main' branch is used instead of 'master', so this link 404s.

This is my first time looking at these specifications, I am not sure if this commit actually fixes the issue at hand.